### PR TITLE
Fix JNI error with ContentValues.put(String, int) on Pico4

### DIFF
--- a/Packages/com.styly.device-id-provider/Runtime/Providers/AndroidDeviceIdProvider.cs
+++ b/Packages/com.styly.device-id-provider/Runtime/Providers/AndroidDeviceIdProvider.cs
@@ -181,7 +181,12 @@ namespace Styly.DeviceIdProvider
             bool needsPending = sdk >= 29 && sdk <= 30; // Android 10-11
 
             if (needsPending)
-                values.Call("put", "is_pending", 1);
+            {
+                using (var one = new AndroidJavaObject("java.lang.Integer", 1))
+                {
+                    values.Call("put", "is_pending", one);
+                }
+            }
 
             AndroidJavaObject uri = null;
             try
@@ -199,11 +204,14 @@ namespace Styly.DeviceIdProvider
 
                 if (needsPending)
                 {
-                    var cv = new AndroidJavaObject("android.content.ContentValues");
-                    cv.Call("put", "is_pending", 0);
-                    int updated = resolver.Call<int>("update", uri, cv, null, null);
-                    if (updated <= 0)
-                        Debug.LogWarning("[DeviceIdProvider] Failed to clear IS_PENDING on created image");
+                    using (var cv = new AndroidJavaObject("android.content.ContentValues"))
+                    using (var zero = new AndroidJavaObject("java.lang.Integer", 0))
+                    {
+                        cv.Call("put", "is_pending", zero);
+                        int updated = resolver.Call<int>("update", uri, cv, null, null);
+                        if (updated <= 0)
+                            Debug.LogWarning("[DeviceIdProvider] Failed to clear IS_PENDING on created image");
+                    }
                 }
             }
             catch


### PR DESCRIPTION
## Summary
- Fix JNI method resolution error on Pico4 by explicitly creating `java.lang.Integer` objects instead of passing C# int values directly to `ContentValues.put()`
- Add proper `using` statement for `ContentValues` to prevent resource leaks

## Related Issue
Fixes #13

## Test plan
- [ ] Test on Pico4 device to verify the error no longer occurs
- [ ] Test on Pico4U to ensure no regression

🤖 Generated with [Claude Code](https://claude.ai/code)