### PR TITLE
Fix: isolate device ID per Editor instance to support ParrelSync

### DIFF
--- a/Packages/com.styly.device-id-provider/Runtime/Providers/StandaloneDeviceIdProvider.cs
+++ b/Packages/com.styly.device-id-provider/Runtime/Providers/StandaloneDeviceIdProvider.cs
@@ -1,6 +1,8 @@
 #if UNITY_2018_4_OR_NEWER
 using System;
 using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 using UnityEngine;
 
 namespace Styly.Device
@@ -61,9 +63,31 @@ namespace Styly.Device
                 baseDirectory = Application.persistentDataPath;
             }
 
+#if UNITY_EDITOR
+            // In the Editor, isolate each Editor instance (including ParrelSync clones) by using
+            // a subdirectory derived from a stable hash of Application.dataPath, which is unique
+            // per project/clone directory.
+            var editorHash = ComputeStableHash(Application.dataPath);
+            var directory = Path.Combine(baseDirectory, VendorFolderName, ProductFolderName, editorHash);
+#else
             var directory = Path.Combine(baseDirectory, VendorFolderName, ProductFolderName);
+#endif
             return Path.Combine(directory, DeviceIdFileName);
         }
+
+#if UNITY_EDITOR
+        private static string ComputeStableHash(string input)
+        {
+            using (var sha = SHA256.Create())
+            {
+                var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(input));
+                var sb = new StringBuilder(16);
+                for (var i = 0; i < 8; i++)
+                    sb.Append(bytes[i].ToString("x2"));
+                return sb.ToString();
+            }
+        }
+#endif
 
         private static string TryReadGuid(string path)
         {

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ The runtime package selects a platform-specific implementation at runtime based 
 
 ### Windows and macOS
 
-- The standalone provider writes the GUID to a text file located in the user's application data directory: `%LOCALAPPDATA%/Styly/Device-ID-Provider/device.id` on Windows and `~/Library/Application Support/Styly/Device-ID-Provider/device.id` on macOS.
+- In Windows and macOS Players, the standalone provider writes the GUID to a text file located in the user's application data directory: `%LOCALAPPDATA%/Styly/Device-ID-Provider/device.id` on Windows and `~/Library/Application Support/Styly/Device-ID-Provider/device.id` on macOS.
+- In the Unity Editor, the provider stores the GUID under an additional subdirectory derived from a stable hash of `Application.dataPath`. This isolates the device ID per project directory, ParrelSync clone, or Multiplayer Play Mode virtual player instead of sharing one Editor-wide file.
 - If those special folders are unavailable (for example in restricted environments), the provider falls back to `Application.persistentDataPath`.
 - The provider validates existing file contents and regenerates the GUID if the file is missing or corrupted.
 


### PR DESCRIPTION
## Summary

- `StandaloneDeviceIdProvider.ResolveStoragePath()` now uses a `#if UNITY_EDITOR` branch that appends a SHA256-derived subdirectory (based on `Application.dataPath`) to the storage path
- Each Editor instance / ParrelSync clone has a distinct `Application.dataPath`, so each gets its own `device.id` file
- Player builds are unaffected — they continue to use the existing flat path

## Notes

- Uses `SHA256` (via `System.Security.Cryptography`) instead of `GetHashCode()` to guarantee hash stability across process restarts
- Existing single-instance Editor users will receive a new GUID on first launch after upgrade (Editor-only, one-time)

Closes #19

## Test plan

- [ ] Open a Unity project using this package in the Unity Editor — confirm `GetDeviceID()` returns a stable GUID across Editor restarts
- [ ] Create a ParrelSync clone and open it in a second Editor — confirm each instance returns a **different** GUID
- [ ] Build a standalone player — confirm the player uses the flat (non-hashed) path and returns the same GUID as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)